### PR TITLE
Added in changes to facilitate the use of Docker.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!bin/Debug/netcoreapp1.0/publish/*
+!*.pfx

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,26 @@
+November 14, 2016 - cycprime
+ *  Modified CHANGELOG to outline the changes made in the commit for 
+    November 14, 2016.  Most of the changes are for facilitating the 
+    use of Docker with cycprime/QuotesAPI and cycprime/QuotesAPIMySQL.
+
+ *  Modified project.json to publish Swagger's api.json, and database
+    configuration, Config/dbsettings.json.
+
+ *  Modified Dockerfile to create the corresponding QuotesAPI image from
+    the published files from .NET Core.
+
+ *  Created .dockerignore file to include only the published files as well
+    any pfx files when creating the Docker image.
+
+ *  Added env/runtime/sample.env to provide a sample file to include in 
+    Docker container creation for the database (cycprime/QuotesAPIMySQL).
+
+ *  Added Data/SampleQuotes.json to provide a mount point and a sample file 
+    for Docker to use when seeding the database and for adding new quotes 
+    to the database 
+
+
+
 October 14, 2016 - cycprime
  *  Added in README.md to provide cursory instruction on how to 
     download and build the api.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+November 15, 2016 - cycprime
+ *  Updated README.md to include instruction for Docker build.
+
+
 November 14, 2016 - cycprime
  *  Modified CHANGELOG to outline the changes made in the commit for 
     November 14, 2016.  Most of the changes are for facilitating the 

--- a/Data/SampleQuotes.json
+++ b/Data/SampleQuotes.json
@@ -1,0 +1,20 @@
+[
+  {
+    "RefId": "<External Ref ID>",
+    "Content": "<Quote Content>",
+    "Source": "<Source of the Quote>",
+    "SourceUrl": "<URL for the Source>"
+  },
+  {
+    "RefId": "Wulfware-Sample-01",
+    "Content": "If you want a happy ending, that depends, of course, on where you stop your story.",
+    "Source": "Mozzie, White Collar",
+    "SourceUrl": "http://whitecollar.wikia.com/wiki/Top_10_list:Top_10_Mozzie_Quotes"
+  },
+  {
+    "RefId": "Wulfware-Sample-02",
+    "Content": "The reason for time is so that everything doesn't happen at once.",
+    "Source": "Mozzie, White Collar",
+    "SourceUrl": "http://whitecollar.wikia.com/wiki/Top_10_list:Top_10_Mozzie_Quotes"
+  }
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,37 @@
 FROM microsoft/dotnet:latest
 
-COPY . /app
+LABEL description="Random Quotes API Docker image." \ 
+      version="0.1" \
+      author="cycprime"
 
-WORKDIR /app
+# Version of this image
+ENV QUOTEAPI_IMG_VER=0.1 \
+    QUOTEAPI_IMG_NAME="quotesapi" \
+    QUOTEAPI_IMG_DESC="Image for Random Quotes API."
 
-RUN ["dotnet", "restore"]
+# Copy the Quotes API DLL and other published directories and files 
+# onto the /app directory.
+COPY bin/Debug/netcoreapp1.0/publish/ /app/
 
-RUN ["dotnet", "build"]
+# Copy any SSL certificates to the working directory.
+COPY *.pfx /app/
 
-EXPOSE 5000/tcp
+# Create mount point for log directory for convenient backup.
+VOLUME /app/Logs
 
-ENTRYPOINT ["dotnet", "run", "--server.urls", "http://0.0.0.0:5000"]
+# Create mount point for a data directory for convenient quotes addition.
+VOLUME /app/Data
+
+# Make the /app the working directory.
+WORKDIR /app/
+
+## RUN ["dotnet", "restore"]
+
+## RUN ["dotnet", "build"]
+
+# Image supports connection to ports 5000 and 5001 within the container.
+EXPOSE 5000 5001
+
+## ENTRYPOINT ["dotnet", "run", "--server.urls", "http://0.0.0.0:5000"]
+## ENTRYPOINT dotnet /app/QuotesAPI.dll
+ENTRYPOINT ["dotnet", "/app/QuotesAPI.dll"]

--- a/README.md
+++ b/README.md
@@ -178,5 +178,18 @@ A sample file of the NLog configuration is available at `Sample/nlog.config`.
 Once the configuration is put in place, simply modify `appsettings.json` 
 to point to the location of NLog configuration file.
 
+## Docker
+Published DLLs is required before building the image for Docker.  To publish the DLLs and all related files and directories for .NET Core, do the following:
+
+    > dotnet publish
+    
+Once the DLLs and related files and directories have been published, run the normal build process for Docker to create the docker image for QuotesAPI:
+
+    > docker build -t quotesapi .
+    
+The image will create a mount point at `/app/Logs` for log files, `/app/Data` for new quotes files (for seeding or new addition).  Use Docker's `--volume` option to map these mount points to the corresponding data volumes or local directories.
+
+For more information about creating containers based on the QuotesAPI Docker image, please refer to the image, [cycprime/quotesapi](https://hub.docker.com/r/cycprime/quotesapi/), on DockerHub.
+
 ## License
 This web api is licensed under the [MIT License](https://github.com/cycprime/QuotesAPI/blob/master/License.txt).

--- a/env/runtime/sample.env
+++ b/env/runtime/sample.env
@@ -1,0 +1,22 @@
+# Docker environment file for setting up MySQL server for QuoteAPI
+# Please refer to MySQL Docker for tips on best practices:
+# https://github.com/mysql/mysql-docker#notes-tips-gotchas
+
+# Sppecifying the host password
+MYSQL_ROOT_PASSWORD=MyPassword4QuotesAPI
+
+# Name of database to be created on image startup
+# MYSQL_DATABASE=
+
+# Create new user and set the user's password
+# MYSQL_USER=
+# MYSQL_PASSWORD=
+
+# Allows empty root password
+# MYSQL_ALLOW_EMPTY_PASSWORD=yes
+
+# General random initial password
+# MYSQL_RANDOM_ROOT_PASSWORD=yes
+
+# Set the 'root' user password to expired once init is complete.
+# MYSQL_ONETIME_PASSWORD=yes

--- a/project.json
+++ b/project.json
@@ -55,7 +55,9 @@
             "Views",
             "Areas/**/Views",
             "appsettings.json",
+            "api.json",
             "web.config",
+            "Config/dbsettings.json",
             "Config/nlog.config"
         ]
     },


### PR DESCRIPTION
Modified project.json to publish Sqagger's api.json and database configuration, Config/dbsettings.json.

Modified Dockerfile to create the corresponding QuotesAPI image from the published files.

Created .dockerignore file to include only the minimal amount of files required to build the image.

Added env/runtime/sample.env to provide a sample file for creating the database container.

Added Data/SampleQuotes.json to provide a mount point as well as a sample file for use when using Docker with QuotesAPI in console mode to seed or add quotes.